### PR TITLE
Rename `username` to `email` on account signup

### DIFF
--- a/src/client/index.tsx
+++ b/src/client/index.tsx
@@ -49,7 +49,7 @@ const Login = (props: RouteComponentProps<{}>) => (
       />
       <div>
         <label>Email: </label>
-        <input type="text" name="username" />
+        <input type="email" name="username" />
       </div>
       <div>
         <label>Password: </label>
@@ -83,8 +83,8 @@ const Signup = () => (
         render={msg("There is already an account with that email.")}
       />
       <div>
-        <label>Username: </label>
-        <input type="text" name="username" />
+        <label>Email: </label>
+        <input type="email" name="username" />
       </div>
       <div>
         <label>Password: </label>


### PR DESCRIPTION
Renamed `username` to `email`, as well as changed the type from `text` to `email`